### PR TITLE
Improve sorting

### DIFF
--- a/src/api/controller.ts
+++ b/src/api/controller.ts
@@ -98,8 +98,8 @@ export async function searchByContent(
                   )
                       .sort({
                           verified: -1,
-                          holders: -1,
                           score: { $meta: 'textScore' },
+                          holders: -1,
                       })
                       .skip(data.start)
                       .limit(data.limit)

--- a/src/models/token.model.ts
+++ b/src/models/token.model.ts
@@ -73,7 +73,7 @@ export const TokenSchema = new mongoose.Schema<IToken>(
 )
 
 TokenSchema.index({ address: 1, chainId: 1 }, { unique: true })
-TokenSchema.index({ name: 'text', symbol: 'text' })
+TokenSchema.index({ name: 'text', symbol: 'text' }, { weights: { name: 5, symbol: 10 }})
 TokenSchema.index({ chainId: 1 })
 TokenSchema.index({ holders: -1 })
 TokenSchema.index({ verified: -1 })


### PR DESCRIPTION
The current sorting logic prioritizes verified first, followed by holders, and then textScore. However, since legacy tokens often have holders defined while most other tokens do not (e.g., holders is set to NULL), legacy tokens are incorrectly prioritized.

To improve this I have made the following changes:
-  Updated the sorting order to prioritize textScore before holders, as holders can be NULL.
 - Introduced index weights to the textScore calculation, giving higher priority to symbol matches over name matches for more accurate and intuitive sorting.